### PR TITLE
Allow customizing interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Role Variables
 `os_ironic_state_cacert`: CA certificate as used by `os_*` modules' `cacert`
 argument.
 
+`os_ironic_state_interface` is the endpoint URL type to fetch from the service
+catalog. Maybe be one of `public`, `admin`, or `internal`.
+
 `os_ironic_state_name`: Name of the ironic node.
 
 `os_ironic_state_provision_state`: Desired provision state.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ os_ironic_state_auth: {}
 # CA certificate as used by os_* modules' 'cacert' argument.
 os_ironic_state_cacert:
 
+# Endpoint URL type to fetch from the service catalog. Maybe be one of:
+# public, admin, or internal.
+os_networks_interface:
+
 # Name of the ironic node.
 os_ironic_state_name:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
     auth_type: "{{ os_ironic_state_auth_type }}"
     auth: "{{ os_ironic_state_auth }}"
     cacert: "{{ os_ironic_state_cacert | default(omit, true) }}"
+    interface: "{{ os_ironic_state_interface | default(omit, true) }}"
     name: "{{ os_ironic_state_name }}"
     provision_state: "{{ os_ironic_state_provision_state }}"
     timeout: "{{ os_ironic_state_timeout }}"


### PR DESCRIPTION
Most of the os_ ansible modules take an interface or endpoint_type parameter. This adds interface as a configurable parameter as it is most similar to OS_INTERFACE environment variable.