### PR TITLE
Fix use of undefined openstack_cloud_from_module

### DIFF
--- a/library/os_ironic_state.py
+++ b/library/os_ironic_state.py
@@ -78,8 +78,8 @@ try:
 except Exception as e:
     IMPORT_ERRORS.append(e)
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
 
 
 def _choose_id_value(module):


### PR DESCRIPTION
The 'openstack_cloud_from_module' variable was not imported from the
Ansible module utils.